### PR TITLE
feat(webcam): Implement threaded streaming for high FPS

### DIFF
--- a/src/config-parser.c
+++ b/src/config-parser.c
@@ -21,7 +21,7 @@ config_option_t read_config_file(char *path) {
 
     if ((fp = fopen(path, "r")) == NULL) {
         if (debug)
-            fprintf(stderr, "Error: cannot read the config file\n");
+            fprintf(stderr, "Error: cannot read the config file: %s\n", path);
         return NULL;
     }
 

--- a/src/httpd.h
+++ b/src/httpd.h
@@ -184,7 +184,9 @@ void init_mime(char *file, char *def);
 
 /* --- webcam.c ------------------------------------------------- */
 
-int v_capture_image(const char *v_filename, int v_frame_count);
+int v_open_camera(void);
+int v_capture_frame_to_file(const char *v_filename);
+void v_close_camera(void);
 
 /* --- config-parser.c ------------------------------------------ */
 

--- a/src/request.c
+++ b/src/request.c
@@ -14,6 +14,7 @@
 #include <syslog.h>
 #include <time.h>
 #include <unistd.h>
+#include <pthread.h>
 
 #include "httpd.h"
 
@@ -1209,6 +1210,55 @@ int update_printer_config_file(const char *config_file, const char *parameter_na
     return 1;
 }
 
+static pthread_t webcam_thread_id;
+static int webcam_thread_running = 0;
+static time_t last_webcam_request_time = 0;
+static pthread_mutex_t webcam_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *webcam_capture_thread(void *arg) {
+    if (debug) fprintf(stderr, "+++ webcam thread: starting\n");
+    if (v_open_camera() != 0) {
+        if (debug) fprintf(stderr, "--- webcam thread: v_open_camera failed\n");
+        pthread_mutex_lock(&webcam_mutex);
+        webcam_thread_running = 0;
+        pthread_mutex_unlock(&webcam_mutex);
+        return NULL;
+    }
+    if (debug) fprintf(stderr, "+++ webcam thread: v_open_camera successful\n");
+
+    while (1) {
+        pthread_mutex_lock(&webcam_mutex);
+        time_t now = time(NULL);
+        if (now - last_webcam_request_time > 2) {
+            if (debug) fprintf(stderr, "+++ webcam thread: timeout, exiting\n");
+            webcam_thread_running = 0;
+            pthread_mutex_unlock(&webcam_mutex);
+            break;
+        }
+        pthread_mutex_unlock(&webcam_mutex);
+
+        if (debug) fprintf(stderr, "+++ webcam thread: capturing frame\n");
+        // capture one frame to the file "/tmp/cam.jpg"
+        int result = v_capture_frame_to_file("/tmp/cam.tmp");
+        if (result == 0) {
+            if (debug) fprintf(stderr, "+++ webcam thread: capture successful\n");
+            rename("/tmp/cam.tmp", "/tmp/cam.jpg");
+        } else {
+            if (debug) fprintf(stderr, "--- webcam thread: capture failed, result: %d\n", result);
+            // errors, use the default image
+            custom_copy_file("/mnt/UDISK/webfs/webcam/default.jpg", "/tmp/cam.jpg", "wb", NULL);
+        }
+
+        usleep(75000);  // 75ms
+    }
+
+    if (debug) fprintf(stderr, "+++ webcam thread: closing camera\n");
+    v_close_camera();
+    if (debug) fprintf(stderr, "+++ webcam thread: exited\n");
+    pthread_exit(NULL);
+    return NULL;
+}
+
 //==============================================================================================================================
 // CUSTOM PAGES
 void process_custom_pages(char *filename_str, struct REQUEST *req) {
@@ -1290,14 +1340,26 @@ void process_custom_pages(char *filename_str, struct REQUEST *req) {
         // turn off the cache
         req->cache_turn_off = 'Y';
 
-        // capture one frame to the file "/mnt/UDISK/webfs/webcam/cam.jpg"
-        remove("/mnt/UDISK/webfs/webcam/cam.jpg");
-        int result = v_capture_image("/mnt/UDISK/webfs/webcam/cam.tmp", 1);
-        if (!result) {
-            // errors, use the default image
-            custom_copy_file("/mnt/UDISK/webfs/webcam/default.jpg", "/mnt/UDISK/webfs/webcam/cam.tmp", "wb", NULL);
+        pthread_mutex_lock(&webcam_mutex);
+        last_webcam_request_time = time(NULL);
+        if (!webcam_thread_running) {
+            if (debug) fprintf(stderr, "+++ process_custom_pages: starting webcam thread\n");
+            webcam_thread_running = 1;
+            if (pthread_create(&webcam_thread_id, NULL, webcam_capture_thread, NULL) != 0) {
+                if (debug) fprintf(stderr, "--- process_custom_pages: failed to create webcam thread\n");
+                webcam_thread_running = 0;
+            }
         }
-        rename("/mnt/UDISK/webfs/webcam/cam.tmp", "/mnt/UDISK/webfs/webcam/cam.jpg");
+        pthread_mutex_unlock(&webcam_mutex);
+
+        // if cam.jpg doesn't exist, copy default as a placeholder
+        // the background thread will overwrite it.
+        if (access("/tmp/cam.jpg", F_OK) == -1) {
+            custom_copy_file("/mnt/UDISK/webfs/webcam/default.jpg", "/tmp/cam.jpg", "wb", NULL);
+        }
+        
+        // Point the server to the image in tmpfs
+        strcpy(filename_str, "/tmp/cam.jpg");
         goto e_x_i_t;
     }
 

--- a/src/request.c
+++ b/src/request.c
@@ -1216,6 +1216,8 @@ static time_t last_webcam_request_time = 0;
 static pthread_mutex_t webcam_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void *webcam_capture_thread(void *arg) {
+    pthread_detach(pthread_self());
+
     if (debug) fprintf(stderr, "+++ webcam thread: starting\n");
     if (v_open_camera() != 0) {
         if (debug) fprintf(stderr, "--- webcam thread: v_open_camera failed\n");
@@ -1255,7 +1257,6 @@ void *webcam_capture_thread(void *arg) {
     if (debug) fprintf(stderr, "+++ webcam thread: closing camera\n");
     v_close_camera();
     if (debug) fprintf(stderr, "+++ webcam thread: exited\n");
-    pthread_exit(NULL);
     return NULL;
 }
 

--- a/webserver/opt/webfs/webcam/index.html
+++ b/webserver/opt/webfs/webcam/index.html
@@ -14,7 +14,7 @@
         var img = document.getElementById("live-image");
         img.src = img.src.split("?")[0] + "?" + new Date().getTime();
       }
-      setInterval(refreshImage, 2000);
+      setInterval(refreshImage, 125);
     </script>
   </head>
   <body>
@@ -42,12 +42,8 @@
       </div>
       <div id="site_content">
         <h2>AK2 Live Webcam</h2>
-        <div
-          style="
+        <div style="
             text-align: center;
-            border: 3px solid black;
-            width: 640px;
-            height: 480px;
             margin: 0 auto;
           "
         >
@@ -55,7 +51,10 @@
             id="live-image"
             src="cam.jpg"
             alt="Live stream image"
-            style="width: 640px; height: 480px"
+            style="
+              width: 100%;
+              border: 3px solid black;
+            "
           />
         </div>
       </div>


### PR DESCRIPTION
Overhauls the webcam functionality to provide a much smoother, higher frame-rate live stream.

Previously, each request for `cam.jpg` would open the camera device, capture a single frame, and then close the device. This process was extremely slow, resulting in a frame rate of less than 1 FPS and causing unnecessary wear on the flash storage.

The new implementation introduces a background thread for continuous capture:

-   A dedicated pthread is spawned on the first request to the webcam page.
-   This thread keeps the camera device open and continuously captures frames into `/tmp/cam.jpg` (a RAM disk), significantly reducing latency and eliminating flash writes.
-   The thread automatically terminates and releases the camera if no new web requests are received within a 2-second timeout.
-   The frontend refresh interval has been reduced from 2000ms to 125ms, enabling a frame rate of ~8 FPS.

To support this new model, the webcam C API was refactored:
-   `v_capture_image` is replaced by `v_open_camera`, `v_capture_frame_to_file`, and `v_close_camera` for more granular control over the device state.